### PR TITLE
Fix: MinVer does not set AssemblyVersion to a desirable value

### DIFF
--- a/src/TBC.OpenBanking.Jws.Http/src/TBC.OpenBanking.Jws.Http.csproj
+++ b/src/TBC.OpenBanking.Jws.Http/src/TBC.OpenBanking.Jws.Http.csproj
@@ -33,7 +33,7 @@
         <WarningsAsErrors>NU1605</WarningsAsErrors>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true' ">
+    <PropertyGroup Condition=" '$(TF_BUILD)' == 'True' or '$(GITHUB_ACTIONS)' == 'true' ">
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
         <DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>
@@ -41,6 +41,7 @@
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
         <RunAnalyzers>false</RunAnalyzers>
         <RestoreDisableParallel>true</RestoreDisableParallel>
+        <MinVerVerbosity>detailed</MinVerVerbosity>
     </PropertyGroup>
 
     <ItemGroup>
@@ -104,5 +105,12 @@
         <Compile Remove="Internals\Range.cs" />
         <Compile Include="Internals\Range.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
     </ItemGroup>
+
+    <Target Name="TbcJws_CalculateAssemblyVersions" AfterTargets="MinVer">
+        <PropertyGroup>
+            <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).0</AssemblyVersion>
+            <InformationalVersion Condition=" '$(GITHUB_ACTIONS)' == 'true' ">$(MinVerVersion)+$(GITHUB_SHA)</InformationalVersion>
+        </PropertyGroup>
+    </Target>
 
 </Project>

--- a/src/TBC.OpenBanking.Jws/src/TBC.OpenBanking.Jws.csproj
+++ b/src/TBC.OpenBanking.Jws/src/TBC.OpenBanking.Jws.csproj
@@ -33,7 +33,7 @@
         <WarningsAsErrors>NU1605</WarningsAsErrors>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true' ">
+    <PropertyGroup Condition=" '$(TF_BUILD)' == 'True' or '$(GITHUB_ACTIONS)' == 'true' ">
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
         <DisableImplicitAspNetCoreAnalyzers>true</DisableImplicitAspNetCoreAnalyzers>
@@ -41,6 +41,7 @@
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
         <RunAnalyzers>false</RunAnalyzers>
         <RestoreDisableParallel>true</RestoreDisableParallel>
+        <MinVerVerbosity>detailed</MinVerVerbosity>
     </PropertyGroup>
 
     <ItemGroup>
@@ -93,5 +94,12 @@
     <ItemGroup>
         <None Include="..\..\images\icon.png" Pack="true" PackagePath="\" />
     </ItemGroup>
+
+    <Target Name="TbcJws_CalculateAssemblyVersions" AfterTargets="MinVer">
+        <PropertyGroup>
+            <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).0</AssemblyVersion>
+            <InformationalVersion Condition=" '$(GITHUB_ACTIONS)' == 'true' ">$(MinVerVersion)+$(GITHUB_SHA)</InformationalVersion>
+        </PropertyGroup>
+    </Target>
 
 </Project>


### PR DESCRIPTION
Build `$(AssemblyVersion)` manually using MinVer task output values.

Fixes #3